### PR TITLE
Add berries for all remaining elemental types

### DIFF
--- a/mods/tuxemon/db/item/cosmic_berry.json
+++ b/mods/tuxemon/db/item/cosmic_berry.json
@@ -4,7 +4,7 @@
       "type": "base",
       "parameters": [
         "types",
-        "fire"
+        "cosmic"
       ],
       "operator": "not"
     }
@@ -13,13 +13,13 @@
     {
       "type": "switch_type",
       "parameters": [
-        "fire"
+        "cosmic"
       ]
     }
   ],
-  "slug": "fire_berry",
+  "slug": "cosmic_berry",
   "sort": "utility",
-  "sprite": "gfx/items/fire_berry.png",
+  "sprite": "gfx/items/cosmic_berry.png",
   "category": "elements",
   "cost": 450,
   "usable_in": [

--- a/mods/tuxemon/db/item/earth_berry.json
+++ b/mods/tuxemon/db/item/earth_berry.json
@@ -4,7 +4,7 @@
       "type": "base",
       "parameters": [
         "types",
-        "fire"
+        "earth"
       ],
       "operator": "not"
     }
@@ -13,13 +13,13 @@
     {
       "type": "switch_type",
       "parameters": [
-        "fire"
+        "earth"
       ]
     }
   ],
-  "slug": "fire_berry",
+  "slug": "earth_berry",
   "sort": "utility",
-  "sprite": "gfx/items/fire_berry.png",
+  "sprite": "gfx/items/earth_berry.png",
   "category": "elements",
   "cost": 450,
   "usable_in": [

--- a/mods/tuxemon/db/item/frost_berry.json
+++ b/mods/tuxemon/db/item/frost_berry.json
@@ -4,7 +4,7 @@
       "type": "base",
       "parameters": [
         "types",
-        "fire"
+        "frost"
       ],
       "operator": "not"
     }
@@ -13,13 +13,13 @@
     {
       "type": "switch_type",
       "parameters": [
-        "fire"
+        "frost"
       ]
     }
   ],
-  "slug": "fire_berry",
+  "slug": "frost_berry",
   "sort": "utility",
-  "sprite": "gfx/items/fire_berry.png",
+  "sprite": "gfx/items/frost_berry.png",
   "category": "elements",
   "cost": 450,
   "usable_in": [

--- a/mods/tuxemon/db/item/heroic_berry.json
+++ b/mods/tuxemon/db/item/heroic_berry.json
@@ -4,7 +4,7 @@
       "type": "base",
       "parameters": [
         "types",
-        "fire"
+        "heroic"
       ],
       "operator": "not"
     }
@@ -13,13 +13,13 @@
     {
       "type": "switch_type",
       "parameters": [
-        "fire"
+        "heroic"
       ]
     }
   ],
-  "slug": "fire_berry",
+  "slug": "heroic_berry",
   "sort": "utility",
-  "sprite": "gfx/items/fire_berry.png",
+  "sprite": "gfx/items/heroic_berry.png",
   "category": "elements",
   "cost": 450,
   "usable_in": [

--- a/mods/tuxemon/db/item/lightning_berry.json
+++ b/mods/tuxemon/db/item/lightning_berry.json
@@ -4,7 +4,7 @@
       "type": "base",
       "parameters": [
         "types",
-        "fire"
+        "lightning"
       ],
       "operator": "not"
     }
@@ -13,13 +13,13 @@
     {
       "type": "switch_type",
       "parameters": [
-        "fire"
+        "lightning"
       ]
     }
   ],
-  "slug": "fire_berry",
+  "slug": "lightning_berry",
   "sort": "utility",
-  "sprite": "gfx/items/fire_berry.png",
+  "sprite": "gfx/items/lightning_berry.png",
   "category": "elements",
   "cost": 450,
   "usable_in": [

--- a/mods/tuxemon/db/item/metal_berry.json
+++ b/mods/tuxemon/db/item/metal_berry.json
@@ -4,7 +4,7 @@
       "type": "base",
       "parameters": [
         "types",
-        "fire"
+        "metal"
       ],
       "operator": "not"
     }
@@ -13,13 +13,13 @@
     {
       "type": "switch_type",
       "parameters": [
-        "fire"
+        "metal"
       ]
     }
   ],
-  "slug": "fire_berry",
+  "slug": "metal_berry",
   "sort": "utility",
-  "sprite": "gfx/items/fire_berry.png",
+  "sprite": "gfx/items/metal_berry.png",
   "category": "elements",
   "cost": 450,
   "usable_in": [

--- a/mods/tuxemon/db/item/normal_berry.json
+++ b/mods/tuxemon/db/item/normal_berry.json
@@ -4,7 +4,7 @@
       "type": "base",
       "parameters": [
         "types",
-        "metal"
+        "normal"
       ],
       "operator": "not"
     }
@@ -13,13 +13,13 @@
     {
       "type": "switch_type",
       "parameters": [
-        "metal"
+        "normal"
       ]
     }
   ],
-  "slug": "metal_cherry",
+  "slug": "normal_berry",
   "sort": "utility",
-  "sprite": "gfx/items/cherry.png",
+  "sprite": "gfx/items/normal_berry.png",
   "category": "elements",
   "cost": 450,
   "usable_in": [

--- a/mods/tuxemon/db/item/shadow_berry.json
+++ b/mods/tuxemon/db/item/shadow_berry.json
@@ -4,7 +4,7 @@
       "type": "base",
       "parameters": [
         "types",
-        "fire"
+        "shadow"
       ],
       "operator": "not"
     }
@@ -13,13 +13,13 @@
     {
       "type": "switch_type",
       "parameters": [
-        "fire"
+        "shadow"
       ]
     }
   ],
-  "slug": "fire_berry",
+  "slug": "shadow_berry",
   "sort": "utility",
-  "sprite": "gfx/items/fire_berry.png",
+  "sprite": "gfx/items/shadow_berry.png",
   "category": "elements",
   "cost": 450,
   "usable_in": [

--- a/mods/tuxemon/db/item/sky_berry.json
+++ b/mods/tuxemon/db/item/sky_berry.json
@@ -4,7 +4,7 @@
       "type": "base",
       "parameters": [
         "types",
-        "fire"
+        "sky"
       ],
       "operator": "not"
     }
@@ -13,13 +13,13 @@
     {
       "type": "switch_type",
       "parameters": [
-        "fire"
+        "sky"
       ]
     }
   ],
-  "slug": "fire_berry",
+  "slug": "sky_berry",
   "sort": "utility",
-  "sprite": "gfx/items/fire_berry.png",
+  "sprite": "gfx/items/sky_berry.png",
   "category": "elements",
   "cost": 450,
   "usable_in": [

--- a/mods/tuxemon/db/item/venom_berry.json
+++ b/mods/tuxemon/db/item/venom_berry.json
@@ -4,7 +4,7 @@
       "type": "base",
       "parameters": [
         "types",
-        "fire"
+        "venom"
       ],
       "operator": "not"
     }
@@ -13,13 +13,13 @@
     {
       "type": "switch_type",
       "parameters": [
-        "fire"
+        "venom"
       ]
     }
   ],
-  "slug": "fire_berry",
+  "slug": "venom_berry",
   "sort": "utility",
-  "sprite": "gfx/items/fire_berry.png",
+  "sprite": "gfx/items/venom_berry.png",
   "category": "elements",
   "cost": 450,
   "usable_in": [

--- a/mods/tuxemon/db/item/water_berry.json
+++ b/mods/tuxemon/db/item/water_berry.json
@@ -4,7 +4,7 @@
       "type": "base",
       "parameters": [
         "types",
-        "fire"
+        "water"
       ],
       "operator": "not"
     }
@@ -13,13 +13,13 @@
     {
       "type": "switch_type",
       "parameters": [
-        "fire"
+        "water"
       ]
     }
   ],
-  "slug": "fire_berry",
+  "slug": "water_berry",
   "sort": "utility",
-  "sprite": "gfx/items/fire_berry.png",
+  "sprite": "gfx/items/water_berry.png",
   "category": "elements",
   "cost": 450,
   "usable_in": [

--- a/mods/tuxemon/db/item/wood_berry.json
+++ b/mods/tuxemon/db/item/wood_berry.json
@@ -4,7 +4,7 @@
       "type": "base",
       "parameters": [
         "types",
-        "fire"
+        "wood"
       ],
       "operator": "not"
     }
@@ -13,13 +13,13 @@
     {
       "type": "switch_type",
       "parameters": [
-        "fire"
+        "wood"
       ]
     }
   ],
-  "slug": "fire_berry",
+  "slug": "wood_berry",
   "sort": "utility",
-  "sprite": "gfx/items/fire_berry.png",
+  "sprite": "gfx/items/wood_berry.png",
   "category": "elements",
   "cost": 450,
   "usable_in": [

--- a/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
+++ b/mods/tuxemon/l18n/en_US/LC_MESSAGES/base.po
@@ -15,17 +15,83 @@ msgstr ""
 "X-Generator: Weblate 4.3.2\n"
 
 # ITEM TRANSLATIONS ##
+msgid "cosmic_berry"
+msgstr "Cosmic Berry"
+
+msgid "cosmic_berry_description"
+msgstr "It changes monster type to Cosmic."
+
+msgid "earth_berry"
+msgstr "Earth Berry"
+
+msgid "earth_berry_description"
+msgstr "It changes monster type to Earth."
+
 msgid "fire_berry"
 msgstr "Fire Berry"
 
 msgid "fire_berry_description"
 msgstr "It changes monster type to Fire."
 
-msgid "metal_cherry"
-msgstr "Metal Cherry"
+msgid "frost_berry"
+msgstr "Frost Berry"
 
-msgid "metal_cherry_description"
+msgid "frost_berry_description"
+msgstr "It changes monster type to Frost."
+
+msgid "heroic_berry"
+msgstr "Heroic Berry"
+
+msgid "heroic_berry_description"
+msgstr "It changes monster type to Heroic."
+
+msgid "metal_berry"
+msgstr "Metal Berry"
+
+msgid "metal_berry_description"
 msgstr "It changes monster type to Metal."
+
+msgid "lightning_berry"
+msgstr "Lightning Berry"
+
+msgid "lightning_berry_description"
+msgstr "It changes monster type to Lightning."
+
+msgid "normal_berry"
+msgstr "Normal Berry"
+
+msgid "normal_berry_description"
+msgstr "It changes monster type to Normal."
+
+msgid "shadow_berry"
+msgstr "Shadow Berry"
+
+msgid "shadow_berry_description"
+msgstr "It changes monster type to Shadow."
+
+msgid "sky_berry"
+msgstr "Sky Berry"
+
+msgid "sky_berry_description"
+msgstr "It changes monster type to Sky."
+
+msgid "venom_berry"
+msgstr "Venom Berry"
+
+msgid "venom_berry_description"
+msgstr "It changes monster type to Venom."
+
+msgid "water_berry"
+msgstr "Water Berry"
+
+msgid "water_berry_description"
+msgstr "It changes monster type to Water."
+
+msgid "wood_berry"
+msgstr "Wood Berry"
+
+msgid "wood_berry_description"
+msgstr "It changes monster type to Wood."
 
 msgid "potion"
 msgstr "Potion"


### PR DESCRIPTION
## Summary
- rename Metal Cherry to Metal Berry and point it at its dedicated sprite
- add berry items for the cosmic, earth, frost, heroic, lightning, normal, shadow, sky, venom, water, and wood elements
- update English localization strings for every berry

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'yaml', 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_68ccdf0646a483248e02e94332860e60